### PR TITLE
Add row click and text wrapping features to data table

### DIFF
--- a/apps/example/src/app/components/features/ColumnsPage.tsx
+++ b/apps/example/src/app/components/features/ColumnsPage.tsx
@@ -491,6 +491,49 @@ const columns: DataTableColumn<Employee>[] = [
         />
       </Paper>
 
+      {/* Text Wrapping */}
+      <Typography variant="h6" gutterBottom sx={{ fontWeight: 600, mb: 2 }}>
+        Text Wrapping
+      </Typography>
+
+      <Paper elevation={1} sx={{ p: 3, mb: 4 }}>
+        <Typography variant="subtitle1" gutterBottom sx={{ fontWeight: 600 }}>
+          Example: Enable Text Wrapping
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          By default, text in cells is truncated with ellipsis. Use <code>wrapText: true</code> to enable text wrapping for long content.
+        </Typography>
+        <CodeBlock
+          language="ts"
+          code={`const columns: DataTableColumn<Employee>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    size: 200,
+    wrapText: false,              // Default: truncate with ellipsis
+  },
+  {
+    accessorKey: 'description',
+    header: 'Description',
+    size: 300,
+    wrapText: true,               // Enable text wrapping
+  },
+  {
+    accessorKey: 'email',
+    header: 'Email',
+    size: 250,
+    wrapText: false,              // Keep email truncated
+  },
+];`}
+        />
+        <Alert severity="info" sx={{ mt: 2 }}>
+          <Typography variant="body2">
+            <strong>Tip:</strong> Use <code>wrapText: true</code> for columns with long text content (descriptions, notes, comments). 
+            Keep <code>wrapText: false</code> (default) for compact columns like IDs, emails, or short codes.
+          </Typography>
+        </Alert>
+      </Paper>
+
       {/* Custom Filter Component */}
       <Typography variant="h6" gutterBottom sx={{ fontWeight: 600, mb: 2 }}>
         Custom Filter Component

--- a/apps/example/src/app/components/features/SelectionPage.tsx
+++ b/apps/example/src/app/components/features/SelectionPage.tsx
@@ -304,6 +304,101 @@ const isRowSelectable = useCallback(({ row, id }) => {
 
       <Divider sx={{ my: 4 }} />
 
+      {/* Row Click */}
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: 600, mb: 2 }}>
+        Row Click Events
+      </Typography>
+
+      <Alert severity="info" sx={{ mb: 3 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+          Handle Row Clicks
+        </Typography>
+        <Typography variant="body2">
+          You can handle row clicks separately from selection. Use <code>onRowClick</code> for custom actions 
+          (like navigation), and <code>selectOnRowClick</code> to enable selection on row click (in addition to checkbox).
+        </Typography>
+      </Alert>
+
+      <Paper elevation={1} sx={{ p: 3, mb: 4 }}>
+        <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
+          Example: Row Click Handler
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Handle row clicks for navigation or custom actions:
+        </Typography>
+        <CodeBlock
+          language="tsx"
+          code={`<DataTable
+  columns={columns}
+  data={data}
+  enableRowSelection={true}
+  onRowClick={(event, row) => {
+    // Navigate to detail page
+    navigate(\`/employees/\${row.original.id}\`);
+    
+    // Or show a modal
+    setSelectedEmployee(row.original);
+    setModalOpen(true);
+    
+    // Or perform any custom action
+    console.log('Clicked row:', row.original);
+  }}
+/>`}
+        />
+      </Paper>
+
+      <Paper elevation={1} sx={{ p: 3, mb: 4 }}>
+        <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
+          Example: Select on Row Click
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Enable selection when clicking anywhere on the row (not just checkbox):
+        </Typography>
+        <CodeBlock
+          language="tsx"
+          code={`<DataTable
+  columns={columns}
+  data={data}
+  enableRowSelection={true}
+  selectOnRowClick={true}              // Enable selection on row click
+  onRowClick={(event, row) => {
+    // This will still fire, but selection happens automatically
+    console.log('Row clicked:', row.original);
+  }}
+/>`}
+        />
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          <Typography variant="body2">
+            <strong>Note:</strong> When <code>selectOnRowClick</code> is enabled, clicking on checkboxes, buttons, 
+            or links within the row will NOT trigger selection (to prevent conflicts). Only clicking on the row itself will toggle selection.
+          </Typography>
+        </Alert>
+      </Paper>
+
+      <Paper elevation={1} sx={{ p: 3, mb: 4 }}>
+        <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
+          Example: Separate Actions
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Use row click for navigation while keeping selection checkbox-only:
+        </Typography>
+        <CodeBlock
+          language="tsx"
+          code={`<DataTable
+  columns={columns}
+  data={data}
+  enableRowSelection={true}
+  selectOnRowClick={false}             // Selection only via checkbox
+  onRowClick={(event, row) => {
+    // Navigate on row click
+    navigate(\`/employees/\${row.original.id}\`);
+  }}
+/>`}
+        />
+      </Paper>
+
+      <Divider sx={{ my: 4 }} />
+
       {/* Bulk Actions */}
       <Typography variant="h5" gutterBottom sx={{ fontWeight: 600, mb: 2 }}>
         Bulk Actions
@@ -329,6 +424,7 @@ const isRowSelectable = useCallback(({ row, id }) => {
   columns={columns}
   data={data}
   enableRowSelection={true}
+  selectOnRowClick
   enableBulkActions={true}             // Enable bulk actions toolbar
   bulkActions={(selectionState) => {
     // Calculate actual selected count
@@ -384,6 +480,7 @@ const isRowSelectable = useCallback(({ row, id }) => {
           }}
           enableBulkActions={true}
           onSelectionChange={handleSelectionChange}
+          selectOnRowClick   
           bulkActions={(selection) => (
             <Box sx={{ display: 'flex', gap: 1 }}>
               <Button

--- a/apps/example/src/app/components/features/data/columns-metadata.json
+++ b/apps/example/src/app/components/features/data/columns-metadata.json
@@ -27,6 +27,13 @@
           "possibleValues": ["left", "center", "right"]
         },
         {
+          "name": "wrapText",
+          "type": "boolean",
+          "defaultValue": "false",
+          "description": "Controls whether text should wrap or truncate with ellipsis.",
+          "possibleValues": ["true", "false"]
+        },
+        {
           "name": "filterable",
           "type": "boolean",
           "defaultValue": "false",

--- a/apps/example/src/app/components/features/data/data-table-metadata.json
+++ b/apps/example/src/app/components/features/data/data-table-metadata.json
@@ -59,7 +59,10 @@
           "type": "'client' | 'server'",
           "defaultValue": "'client'",
           "description": "Enable server-driven pagination, filtering, and sorting when set to 'server'.",
-          "possibleValues": ["client", "server"]
+          "possibleValues": [
+            "client",
+            "server"
+          ]
         },
         {
           "name": "onFetchData",
@@ -73,7 +76,10 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Whether to fetch data on component mount. Set to false to manually control initial fetch.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "onDataStateChange",
@@ -101,21 +107,30 @@
           "type": "boolean | ((row) => boolean)",
           "defaultValue": "false",
           "description": "Turn on row selection or supply a predicate to disable rows individually.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "enableMultiRowSelection",
           "type": "boolean",
           "defaultValue": "true",
           "description": "Allow toggling multiple rows at once. Combine with selectMode for all-page selection.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "selectMode",
           "type": "'page' | 'all'",
           "defaultValue": "'page'",
           "description": "Choose between page-scoped selection or whole-dataset selection helpers.",
-          "possibleValues": ["page", "all"]
+          "possibleValues": [
+            "page",
+            "all"
+          ]
         },
         {
           "name": "isRowSelectable",
@@ -132,11 +147,31 @@
           "possibleValues": []
         },
         {
+          "name": "selectOnRowClick",
+          "type": "boolean",
+          "defaultValue": "false",
+          "description": "If true, row click will toggle selection.",
+          "possibleValues": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "onRowClick",
+          "type": "(event: React.MouseEvent<HTMLTableRowElement>, row: Row<T>) => void",
+          "defaultValue": "undefined",
+          "description": "Callback when a row is clicked.",
+          "possibleValues": []
+        },
+        {
           "name": "enableBulkActions",
           "type": "boolean",
           "defaultValue": "false",
           "description": "Display the bulk action toolbar when rows are selected.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "bulkActions",
@@ -157,21 +192,30 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Enable global search across all columns.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "enableColumnFilter",
           "type": "boolean",
           "defaultValue": "false",
           "description": "Enable individual column filters.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "filterMode",
           "type": "'client' | 'server'",
           "defaultValue": "'client'",
           "description": "Choose between client-side or server-side filtering.",
-          "possibleValues": ["client", "server"]
+          "possibleValues": [
+            "client",
+            "server"
+          ]
         },
         {
           "name": "onGlobalFilterChange",
@@ -199,14 +243,20 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Enable pagination controls.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "paginationMode",
           "type": "'client' | 'server'",
           "defaultValue": "'client'",
           "description": "Choose between client-side or server-side pagination.",
-          "possibleValues": ["client", "server"]
+          "possibleValues": [
+            "client",
+            "server"
+          ]
         },
         {
           "name": "onPaginationChange",
@@ -227,14 +277,20 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Enable column sorting.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "sortingMode",
           "type": "'client' | 'server'",
           "defaultValue": "'client'",
           "description": "Choose between client-side or server-side sorting.",
-          "possibleValues": ["client", "server"]
+          "possibleValues": [
+            "client",
+            "server"
+          ]
         },
         {
           "name": "onSortingChange",
@@ -255,7 +311,10 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Enable column visibility toggle control in toolbar.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "onColumnVisibilityChange",
@@ -269,7 +328,10 @@
           "type": "boolean",
           "defaultValue": "false",
           "description": "Enable column reordering by drag and drop.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "onColumnDragEnd",
@@ -283,7 +345,10 @@
           "type": "boolean",
           "defaultValue": "false",
           "description": "Enable column pinning to left or right side.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "onColumnPinningChange",
@@ -297,14 +362,20 @@
           "type": "boolean",
           "defaultValue": "false",
           "description": "Enable column resizing by dragging column borders.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "columnResizeMode",
           "type": "'onChange' | 'onEnd'",
           "defaultValue": "'onChange'",
           "description": "When to apply resize: during drag or after release.",
-          "possibleValues": ["onChange", "onEnd"]
+          "possibleValues": [
+            "onChange",
+            "onEnd"
+          ]
         },
         {
           "name": "onColumnSizingChange",
@@ -325,7 +396,10 @@
           "type": "boolean",
           "defaultValue": "true",
           "description": "Enable CSV/Excel export functionality.",
-          "possibleValues": ["true", "false"]
+          "possibleValues": [
+            "true",
+            "false"
+          ]
         },
         {
           "name": "exportFilename",
@@ -362,21 +436,32 @@
           "type": "SlotComponent<BoxProps & { children: ReactNode }>",
           "defaultValue": "DefaultRoot",
           "description": "Root wrapper around the entire table experience.",
-          "possibleValues": ["Box", "Card", "Paper"]
+          "possibleValues": [
+            "Box",
+            "Card",
+            "Paper"
+          ]
         },
         {
           "name": "tableContainer",
           "type": "SlotComponent<TableContainerProps & { enableStickyHeader?: boolean }>",
           "defaultValue": "Paper",
           "description": "Scrollable container hosting the table element.",
-          "possibleValues": ["Paper", "div", "ScrollArea"]
+          "possibleValues": [
+            "Paper",
+            "div",
+            "ScrollArea"
+          ]
         },
         {
           "name": "table",
           "type": "SlotComponent<TableProps & { tableSize?: DataTableSize }>",
           "defaultValue": "MUITable",
           "description": "Underlying MUI table element for styling or virtualization tweaks.",
-          "possibleValues": ["Table", "CustomTable"]
+          "possibleValues": [
+            "Table",
+            "CustomTable"
+          ]
         }
       ]
     },
@@ -390,63 +475,88 @@
           "type": "SlotComponent<ToolbarProps & DataTableToolbarProps>",
           "defaultValue": "DefaultToolbar",
           "description": "Wraps the entire toolbar area including built-in controls and extra filters.",
-          "possibleValues": ["CustomToolbar"]
+          "possibleValues": [
+            "CustomToolbar"
+          ]
         },
         {
           "name": "searchInput",
           "type": "SlotComponent<ComponentProps<'input'>>",
           "defaultValue": "DefaultSearchInput",
           "description": "Replace the global search input element.",
-          "possibleValues": ["TextField", "CustomDebouncedInput"]
+          "possibleValues": [
+            "TextField",
+            "CustomDebouncedInput"
+          ]
         },
         {
           "name": "columnVisibilityControl",
           "type": "SlotComponent<HTMLDivElement>",
           "defaultValue": "ColumnVisibilityToggle",
           "description": "Customize the column visibility toggle button and dropdown.",
-          "possibleValues": ["IconButton", "Menu"]
+          "possibleValues": [
+            "IconButton",
+            "Menu"
+          ]
         },
         {
           "name": "columnCustomFilterControl",
           "type": "SlotComponent<HTMLDivElement>",
           "defaultValue": "ColumnFilterButton",
           "description": "Control the advanced filters button/drawer.",
-          "possibleValues": ["Button", "MenuItem"]
+          "possibleValues": [
+            "Button",
+            "MenuItem"
+          ]
         },
         {
           "name": "columnPinningControl",
           "type": "SlotComponent<HTMLDivElement>",
           "defaultValue": "ColumnPinningButton",
           "description": "Trigger and menu for column pinning.",
-          "possibleValues": ["IconButton", "MenuItem"]
+          "possibleValues": [
+            "IconButton",
+            "MenuItem"
+          ]
         },
         {
           "name": "tableSizeControl",
           "type": "SlotComponent<HTMLDivElement>",
           "defaultValue": "DensityControl",
           "description": "Button group for switching compact/comfortable modes.",
-          "possibleValues": ["ToggleButtonGroup"]
+          "possibleValues": [
+            "ToggleButtonGroup"
+          ]
         },
         {
           "name": "resetButton",
           "type": "SlotComponent<ComponentProps<'button'>>",
           "defaultValue": "ResetButton",
           "description": "Resets filters, sorting, and column settings.",
-          "possibleValues": ["Button", "IconButton"]
+          "possibleValues": [
+            "Button",
+            "IconButton"
+          ]
         },
         {
           "name": "exportButton",
           "type": "SlotComponent<ComponentProps<'button'>>",
           "defaultValue": "DefaultExportButton",
           "description": "Swap the export trigger with your own button.",
-          "possibleValues": ["Button", "LoadingButton"]
+          "possibleValues": [
+            "Button",
+            "LoadingButton"
+          ]
         },
         {
           "name": "bulkActionsToolbar",
           "type": "SlotComponent<ToolbarProps & { selectionState: any }>",
           "defaultValue": "DefaultBulkActionsToolbar",
           "description": "Replace the selection bulk actions toolbar when rows are selected.",
-          "possibleValues": ["Toolbar", "Stack"]
+          "possibleValues": [
+            "Toolbar",
+            "Stack"
+          ]
         }
       ]
     },
@@ -460,63 +570,91 @@
           "type": "SlotComponent<TableHeadProps>",
           "defaultValue": "DefaultHeader",
           "description": "Custom table head wrapper allowing sticky headers and drag-n-drop.",
-          "possibleValues": ["TableHead"]
+          "possibleValues": [
+            "TableHead"
+          ]
         },
         {
           "name": "headerRow",
           "type": "SlotComponent<TableRowProps & { headerGroups: any[] }>",
           "defaultValue": "DefaultHeaderRow",
           "description": "Render the header row, enabling draggable columns or grouping.",
-          "possibleValues": ["TableRow"]
+          "possibleValues": [
+            "TableRow"
+          ]
         },
         {
           "name": "headerCell",
           "type": "SlotComponent<TableCellProps & { column: Column<T> }>",
           "defaultValue": "DefaultHeaderCell",
           "description": "Override individual header cells for custom sorting UI.",
-          "possibleValues": ["TableCell", "ButtonBase"]
+          "possibleValues": [
+            "TableCell",
+            "ButtonBase"
+          ]
         },
         {
           "name": "body",
           "type": "SlotComponent<TableBodyProps & { rows: Row<T>[] }>",
           "defaultValue": "DefaultBody",
           "description": "Wraps all visible rows, useful for virtualization.",
-          "possibleValues": ["TableBody"]
+          "possibleValues": [
+            "TableBody"
+          ]
         },
         {
           "name": "row",
           "type": "SlotComponent<TableRowProps & { row: Row<T>; index: number }>",
           "defaultValue": "DefaultRow",
           "description": "Control how each body row renders including hover states.",
-          "possibleValues": ["TableRow", "VirtualRow"]
+          "possibleValues": [
+            "TableRow",
+            "VirtualRow"
+          ]
+        },
+        {
+          "name": "onRowClick",
+          "type": "(event: React.MouseEvent<HTMLTableRowElement>, row: Row<T>) => void",
+          "defaultValue": "undefined",
+          "description": "Callback when a row is clicked.",
+          "possibleValues": []
         },
         {
           "name": "cell",
           "type": "SlotComponent<TableCellProps & { value: any }>",
           "defaultValue": "DefaultCell",
           "description": "Override individual cell rendering and styling.",
-          "possibleValues": ["TableCell", "Span"]
+          "possibleValues": [
+            "TableCell",
+            "Span"
+          ]
         },
         {
           "name": "loadingRow",
           "type": "SlotComponent<TableRowProps & { rowCount: number; colSpan: number }>",
           "defaultValue": "LoadingRow",
           "description": "Custom loading placeholder when data is being fetched.",
-          "possibleValues": ["TableRow"]
+          "possibleValues": [
+            "TableRow"
+          ]
         },
         {
           "name": "emptyRow",
           "type": "SlotComponent<TableRowProps & { colSpan: number; message: string }>",
           "defaultValue": "EmptyRow",
           "description": "Custom empty state row when there is no data.",
-          "possibleValues": ["TableRow"]
+          "possibleValues": [
+            "TableRow"
+          ]
         },
         {
           "name": "expandedRow",
           "type": "SlotComponent<TableRowProps & { row: Row<T>; colSpan: number }>",
           "defaultValue": "ExpandedRow",
           "description": "Render content when a row is expanded.",
-          "possibleValues": ["TableRow"]
+          "possibleValues": [
+            "TableRow"
+          ]
         }
       ]
     },
@@ -530,14 +668,20 @@
           "type": "SlotComponent<BoxProps & { enableStickyFooter?: boolean }>",
           "defaultValue": "DefaultFooter",
           "description": "Wrap the footer container which hosts pagination and custom content.",
-          "possibleValues": ["Box", "Stack"]
+          "possibleValues": [
+            "Box",
+            "Stack"
+          ]
         },
         {
           "name": "pagination",
           "type": "SlotComponent<DataTablePaginationProps>",
           "defaultValue": "DefaultPagination",
           "description": "Override the pagination component (rows per page, navigation).",
-          "possibleValues": ["TablePagination", "CustomPagination"]
+          "possibleValues": [
+            "TablePagination",
+            "CustomPagination"
+          ]
         }
       ]
     },
@@ -551,14 +695,18 @@
           "type": "SlotComponent<DataTableColumn<T>>",
           "defaultValue": "createSelectionColumn(config)",
           "description": "Provide a custom selection column implementation.",
-          "possibleValues": ["DataTableColumn"]
+          "possibleValues": [
+            "DataTableColumn"
+          ]
         },
         {
           "name": "expandColumn",
           "type": "SlotComponent<DataTableColumn<T>>",
           "defaultValue": "createExpandingColumn(config)",
           "description": "Provide a custom expansion toggle column.",
-          "possibleValues": ["DataTableColumn"]
+          "possibleValues": [
+            "DataTableColumn"
+          ]
         }
       ]
     }
@@ -574,21 +722,32 @@
           "type": "DataTableToolbarProps",
           "defaultValue": "{}",
           "description": "Configure built-in toolbar options like search, filters, export, and custom labels.",
-          "possibleValues": ["enableGlobalFilter", "enableColumnVisibility", "title"]
+          "possibleValues": [
+            "enableGlobalFilter",
+            "enableColumnVisibility",
+            "title"
+          ]
         },
         {
           "name": "searchInput",
           "type": "{ placeholder?: string; debounceMs?: number }",
           "defaultValue": "{ placeholder: 'Search…' }",
           "description": "Customize the global search input placeholder, debounce, and adornments.",
-          "possibleValues": ["placeholder", "InputProps"]
+          "possibleValues": [
+            "placeholder",
+            "InputProps"
+          ]
         },
         {
           "name": "exportButton",
           "type": "{ filename?: string; variant?: 'text' | 'outlined' | 'contained' }",
           "defaultValue": "{ filename: 'export', variant: 'outlined' }",
           "description": "Pass props to the export trigger without replacing the button component.",
-          "possibleValues": ["filename", "variant", "color"]
+          "possibleValues": [
+            "filename",
+            "variant",
+            "color"
+          ]
         }
       ]
     },
@@ -602,21 +761,33 @@
           "type": "{ maxHeight?: number | string; enableStickyHeader?: boolean }",
           "defaultValue": "{ maxHeight: undefined }",
           "description": "Control scroll height and sticky header behavior without swapping components.",
-          "possibleValues": ["maxHeight", "enableStickyHeader", "enableVirtualization"]
+          "possibleValues": [
+            "maxHeight",
+            "enableStickyHeader",
+            "enableVirtualization"
+          ]
         },
         {
           "name": "table",
           "type": "{ size?: 'compact' | 'medium' | 'comfortable'; stickyHeader?: boolean }",
           "defaultValue": "{ size: 'medium' }",
           "description": "Adjust table density and sticky header options.",
-          "possibleValues": ["size", "stickyHeader", "fitToScreen"]
+          "possibleValues": [
+            "size",
+            "stickyHeader",
+            "fitToScreen"
+          ]
         },
         {
           "name": "row",
           "type": "{ hover?: boolean; striped?: boolean }",
           "defaultValue": "{ hover: true }",
           "description": "Set hover, stripe, and expansion behavior for rows.",
-          "possibleValues": ["hover", "striped", "onClick"]
+          "possibleValues": [
+            "hover",
+            "striped",
+            "onClick"
+          ]
         }
       ]
     },
@@ -630,14 +801,21 @@
           "type": "{ rowsPerPageOptions?: number[]; showFirstButton?: boolean; showLastButton?: boolean }",
           "defaultValue": "{ rowsPerPageOptions: [10, 25, 50] }",
           "description": "Control page size options, navigation buttons, and localized labels.",
-          "possibleValues": ["rowsPerPageOptions", "showFirstButton", "labelRowsPerPage"]
+          "possibleValues": [
+            "rowsPerPageOptions",
+            "showFirstButton",
+            "labelRowsPerPage"
+          ]
         },
         {
           "name": "footer",
           "type": "{ stickyFooter?: boolean }",
           "defaultValue": "{ stickyFooter: false }",
           "description": "Enable sticky footer or add custom padding without replacing the container.",
-          "possibleValues": ["stickyFooter", "sx"]
+          "possibleValues": [
+            "stickyFooter",
+            "sx"
+          ]
         }
       ]
     }

--- a/apps/example/src/theme/palette.ts
+++ b/apps/example/src/theme/palette.ts
@@ -12,7 +12,6 @@ export type ColorSchema =
 declare module '@mui/material/styles/createPalette' {
     interface TypeBackground {
         neutral: string;
-        hover: string;
     }
 
     interface SimplePaletteColorOptions {
@@ -157,9 +156,7 @@ export const lightPalette = {
         appPink: '#f7dbf8',
         appPositive: '#d6f7e4',
         appNegative: 'rgba(157, 255, 118, 0.49)',
-        appTheme: 'rgb(218 230 248)',
-        hover: '#f7f8f9',
-        selected: '#e8e8e9',
+        appTheme: 'rgb(218 230 248)'
     },
 
     action: {
@@ -183,8 +180,6 @@ export const darkPalette = {
         appPositive: '#567a5f',
         appNegative: 'rgba(67, 109, 49, 0.7)',
         appTheme: 'rgb(98 108 116 / 0.9)',
-        hover: '#1c252e',
-        selected: '#27323b',
     },
     action: {
         ...COMMON.action,

--- a/apps/example/src/theme/palette.ts
+++ b/apps/example/src/theme/palette.ts
@@ -12,6 +12,7 @@ export type ColorSchema =
 declare module '@mui/material/styles/createPalette' {
     interface TypeBackground {
         neutral: string;
+        hover: string;
     }
 
     interface SimplePaletteColorOptions {
@@ -157,6 +158,8 @@ export const lightPalette = {
         appPositive: '#d6f7e4',
         appNegative: 'rgba(157, 255, 118, 0.49)',
         appTheme: 'rgb(218 230 248)',
+        hover: '#f7f8f9',
+        selected: '#e8e8e9',
     },
 
     action: {
@@ -180,6 +183,8 @@ export const darkPalette = {
         appPositive: '#567a5f',
         appNegative: 'rgba(67, 109, 49, 0.7)',
         appTheme: 'rgb(98 108 116 / 0.9)',
+        hover: '#1c252e',
+        selected: '#27323b',
     },
     action: {
         ...COMMON.action,

--- a/packages/react-tanstack-data-table/src/lib/components/headers/draggable-header.tsx
+++ b/packages/react-tanstack-data-table/src/lib/components/headers/draggable-header.tsx
@@ -42,7 +42,7 @@ export function DraggableHeader<T>(props: DraggableHeaderProps<T>) {
     // Extract slot-specific props with enhanced merging
     const sortIconAscSlotProps = extractSlotProps(slotProps, 'sortIconAsc');
     const sortIconDescSlotProps = extractSlotProps(slotProps, 'sortIconDesc');
-    
+
     const SortIconAscSlot = getSlotComponent(slots, 'sortIconAsc', ArrowUpwardOutlined);
     const SortIconDescSlot = getSlotComponent(slots, 'sortIconDesc', ArrowDownwardOutlined);
 
@@ -271,8 +271,15 @@ export function DraggableHeader<T>(props: DraggableHeaderProps<T>) {
                 padding: dragOver ? '0 0 0 -2px' : '0',
                 width: '100%',
                 height: '100%',
+                minWidth: '0',
                 '&:active': {
                     cursor: draggable ? 'grabbing' : 'pointer',
+                },
+                '.header-content': {
+                    display: 'inline-flex',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
                 },
                 ...containerSx,
             },
@@ -298,12 +305,15 @@ export function DraggableHeader<T>(props: DraggableHeaderProps<T>) {
         >
             <Box
                 component="span"
+                className='header-wrapper'
                 sx={{
                     display: 'inline-flex',
                     gap: 1,
                 }}
             >
-                {flexRender(header.column.columnDef.header, header.getContext())}
+                <Box component="span" className='header-content'>
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                </Box>
                 {getSortIcon()}
             </Box>
         </Box>

--- a/packages/react-tanstack-data-table/src/lib/components/rows/data-table-row.tsx
+++ b/packages/react-tanstack-data-table/src/lib/components/rows/data-table-row.tsx
@@ -7,12 +7,13 @@
  * - Hover effects
  * - Striped styling
  */
-import { TableRow, TableCell, Collapse, TableRowProps, TableCellProps, SxProps, tableRowClasses, alpha } from '@mui/material';
+import { TableRow, TableCell, Collapse, TableRowProps, TableCellProps, SxProps, tableRowClasses } from '@mui/material';
 import { flexRender, Row } from '@tanstack/react-table';
 import { ReactNode } from 'react';
 
 import { getPinnedColumnStyle, getColumnAlignment } from '../../utils';
 import { getSlotComponent, mergeSlotProps, extractSlotProps } from '../../utils/slot-helpers';
+import { useDataTableContext } from '../../contexts/data-table-context';
 
 export interface DataTableRowProps<T> extends TableRowProps {
     row: Row<T>;
@@ -21,6 +22,9 @@ export interface DataTableRowProps<T> extends TableRowProps {
     isOdd?: boolean;
     renderSubComponent?: (row: Row<T>) => ReactNode;
     disableStickyHeader?: boolean;
+    // Row click props
+    onRowClick?: (event: React.MouseEvent<HTMLTableRowElement>, row: Row<T>) => void;
+    selectOnRowClick?: boolean; // If true, row click will toggle selection (default: false)
     // Enhanced customization props
     cellProps?: TableCellProps;
     expandedRowProps?: TableRowProps;
@@ -44,6 +48,8 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
         isOdd = false,
         renderSubComponent,
         disableStickyHeader = false,
+        onRowClick,
+        selectOnRowClick = false,
         cellProps,
         expandedRowProps,
         expandedCellProps,
@@ -53,37 +59,61 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
         slotProps,
         ...otherProps
     } = props;
+    const { table } = useDataTableContext();
 
     // Extract slot-specific props with enhanced merging
     const cellSlotProps = extractSlotProps(slotProps, 'cell');
     const expandedRowSlotProps = extractSlotProps(slotProps, 'expandedRow');
     const rowSlotProps = extractSlotProps(slotProps, 'row');
-    
+
     const CellSlot = getSlotComponent(slots, 'cell', TableCell);
     const ExpandedRowSlot = getSlotComponent(slots, 'expandedRow', TableRow);
     const TableRowSlot = getSlotComponent(slots, 'row', TableRow);
+
+    // Handle row click
+    const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
+        // Check if click target is a checkbox, button, or interactive element
+        const target = event.target as HTMLElement;
+        const isCheckboxClick = target.closest('input[type="checkbox"]') !== null;
+        const isButtonClick = target.closest('button') !== null;
+        const isLinkClick = target.closest('a') !== null;
+        const isInteractiveElement = isCheckboxClick || isButtonClick || isLinkClick;
+
+        // If selectOnRowClick is enabled and it's not a checkbox/interactive element click, toggle selection
+        if (selectOnRowClick && !isCheckboxClick && !isButtonClick && !isLinkClick && table?.toggleRowSelected) {
+            table.toggleRowSelected(row.id);
+        }
+
+        // Always call onRowClick if provided
+        if (onRowClick) {
+            onRowClick(event, row);
+        }
+    };
 
     // Merge all props for maximum flexibility
     const mergedRowProps = mergeSlotProps(
         {
             hover: enableHover,
+            selected: !!table?.getIsRowSelected?.(row.id),
+            onClick: (onRowClick || selectOnRowClick) ? handleRowClick : undefined,
             sx: (theme) => ({
                 // set the row background as a variable
                 '--row-bg': enableStripes && isOdd
-                    ? theme.palette.action.hover
+                    ? theme.palette.background.hover
                     : theme.palette.background.paper,
-
                 backgroundColor: 'var(--row-bg)',
-
                 // keep the variable in sync for hover/selected
                 ...(enableHover && {
-                    '&:hover': { '--row-bg': theme.palette.action.hover },
+                    '&:hover': { '--row-bg': theme.palette.background.hover },
                 }),
                 [`&.${tableRowClasses.selected}`]: {
-                    '--row-bg': alpha(theme.palette.primary.dark, 0.08),
+                    '--row-bg': theme.palette.grey[200],
                     backgroundColor: 'var(--row-bg)',
                 },
-
+                // Add cursor pointer if row is clickable
+                ...((onRowClick || selectOnRowClick) && {
+                    cursor: 'pointer',
+                }),
                 ...containerSx,
             }),
         },
@@ -112,6 +142,7 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
                     // Get minSize and maxSize from column definition
                     const minSize = cell.column.columnDef?.minSize;
                     const maxSize = cell.column.columnDef.maxSize;
+                    const wrapText = cell.column.columnDef.wrapText ?? false;
 
                     const mergedCellProps = mergeSlotProps(
                         {
@@ -128,6 +159,7 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
                                     disableStickyHeader,
                                     isLastLeftPinnedColumn: isPinned === 'left' && cell.column.getIsLastColumn('left'),
                                     isFirstRightPinnedColumn: isPinned === 'right' && cell.column.getIsFirstColumn('right'),
+                                    wrapText,
                                 }),
                             },
                         },
@@ -152,7 +184,7 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
                 >
                     <CellSlot
                         colSpan={row.getVisibleCells().length + 1}
-                        sx={{ 
+                        sx={{
                             py: 0,
                             ...expandedCellProps?.sx,
                         }}

--- a/packages/react-tanstack-data-table/src/lib/components/rows/data-table-row.tsx
+++ b/packages/react-tanstack-data-table/src/lib/components/rows/data-table-row.tsx
@@ -7,7 +7,7 @@
  * - Hover effects
  * - Striped styling
  */
-import { TableRow, TableCell, Collapse, TableRowProps, TableCellProps, SxProps, tableRowClasses } from '@mui/material';
+import { TableRow, TableCell, Collapse, TableRowProps, TableCellProps, SxProps, tableRowClasses, Box } from '@mui/material';
 import { flexRender, Row } from '@tanstack/react-table';
 import { ReactNode } from 'react';
 
@@ -77,7 +77,6 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
         const isCheckboxClick = target.closest('input[type="checkbox"]') !== null;
         const isButtonClick = target.closest('button') !== null;
         const isLinkClick = target.closest('a') !== null;
-        const isInteractiveElement = isCheckboxClick || isButtonClick || isLinkClick;
 
         // If selectOnRowClick is enabled and it's not a checkbox/interactive element click, toggle selection
         if (selectOnRowClick && !isCheckboxClick && !isButtonClick && !isLinkClick && table?.toggleRowSelected) {
@@ -99,15 +98,15 @@ export function DataTableRow<T>(props: DataTableRowProps<T>) {
             sx: (theme) => ({
                 // set the row background as a variable
                 '--row-bg': enableStripes && isOdd
-                    ? theme.palette.background.hover
+                    ? theme.palette.action.hover
                     : theme.palette.background.paper,
                 backgroundColor: 'var(--row-bg)',
                 // keep the variable in sync for hover/selected
                 ...(enableHover && {
-                    '&:hover': { '--row-bg': theme.palette.background.hover },
+                    '&:hover': { '--row-bg': theme.palette.action.hover },
                 }),
                 [`&.${tableRowClasses.selected}`]: {
-                    '--row-bg': theme.palette.grey[200],
+                    '--row-bg': theme.palette.action.selected,
                     backgroundColor: 'var(--row-bg)',
                 },
                 // Add cursor pointer if row is clickable

--- a/packages/react-tanstack-data-table/src/lib/components/table/data-table.tsx
+++ b/packages/react-tanstack-data-table/src/lib/components/table/data-table.tsx
@@ -100,6 +100,10 @@ export const DataTable = forwardRef<DataTableApi<any>, DataTableProps<any>>(func
     isRowSelectable,
     onSelectionChange,
 
+    // Row click props
+    onRowClick,
+    selectOnRowClick = false,
+
     // Bulk action props
     enableBulkActions = false,
     bulkActions,
@@ -1680,6 +1684,8 @@ export const DataTable = forwardRef<DataTableApi<any>, DataTableProps<any>>(func
                                 isOdd={virtualRow.index % 2 === 1}
                                 renderSubComponent={renderSubComponent}
                                 disableStickyHeader={enableStickyHeaderOrFooter}
+                                onRowClick={onRowClick}
+                                selectOnRowClick={selectOnRowClick}
                                 slots={slots}
                                 slotProps={slotProps}
                             />
@@ -1710,6 +1716,8 @@ export const DataTable = forwardRef<DataTableApi<any>, DataTableProps<any>>(func
                 isOdd={index % 2 === 1}
                 renderSubComponent={renderSubComponent}
                 disableStickyHeader={enableStickyHeaderOrFooter}
+                onRowClick={onRowClick}
+                selectOnRowClick={selectOnRowClick}
                 slots={slots}
                 slotProps={slotProps}
             />
@@ -1729,6 +1737,8 @@ export const DataTable = forwardRef<DataTableApi<any>, DataTableProps<any>>(func
         enableStripes,
         renderSubComponent,
         enableStickyHeaderOrFooter,
+        onRowClick,
+        selectOnRowClick,
         slots,
     ]);
 

--- a/packages/react-tanstack-data-table/src/lib/components/table/data-table.types.ts
+++ b/packages/react-tanstack-data-table/src/lib/components/table/data-table.types.ts
@@ -63,6 +63,10 @@ export interface DataTableProps<T> {
     
     onSelectionChange?: (selection: SelectionState) => void;
 
+    // Row click props
+    onRowClick?: (event: React.MouseEvent<HTMLTableRowElement>, row: Row<T>) => void;
+    selectOnRowClick?: boolean; // If true, row click will toggle selection (default: false)
+
     // Bulk action props
     enableBulkActions?: boolean;
     bulkActions?: (selectionState: SelectionState) => ReactNode;

--- a/packages/react-tanstack-data-table/src/lib/components/toolbar/column-pinning-control.tsx
+++ b/packages/react-tanstack-data-table/src/lib/components/toolbar/column-pinning-control.tsx
@@ -89,7 +89,7 @@ export function ColumnPinningControl(props: ColumnPinningControlProps = {}) {
     };
 
     const handleUnpinAll = useCallback(() => {
-        table.setColumnPinning(table.initialState.columnPinning || {});
+        table?.setColumnPinning(table?.initialState?.columnPinning || {});
     }, [table]);
 
     // Count only user-pinned columns (exclude system columns like select and action)

--- a/packages/react-tanstack-data-table/src/lib/types/column.types.ts
+++ b/packages/react-tanstack-data-table/src/lib/types/column.types.ts
@@ -24,6 +24,7 @@ declare module '@tanstack/table-core' {
         align?: 'left' | 'center' | 'right';
         filterable?: boolean;
         hideInExport?: boolean;
+        wrapText?: boolean; // If true, text will wrap; if false, text will truncate with ellipsis (default: false)
         editComponent?: React.ComponentType<{
             value: any;
             onChange: (value: any) => void;

--- a/packages/react-tanstack-data-table/src/lib/types/export.types.ts
+++ b/packages/react-tanstack-data-table/src/lib/types/export.types.ts
@@ -115,6 +115,7 @@ export interface PinnedColumnStyleOptions {
     disableStickyHeader?: boolean;
     isLastLeftPinnedColumn?: boolean;
     isFirstRightPinnedColumn?: boolean;
+    wrapText?: boolean; // If true, text will wrap; if false, text will truncate with ellipsis (default: false)
 }
 
 /**


### PR DESCRIPTION
Introduces `onRowClick` and `selectOnRowClick` props to the data table for handling row click events and toggling selection via row clicks. Adds `wrapText` column option to control cell text wrapping versus truncation. Updates documentation, metadata, and styling helpers to support these features, and enhances row/column rendering logic for improved interactivity and customization.